### PR TITLE
also discard messageID if invalid UTF-8

### DIFF
--- a/imap/table_imap_message.go
+++ b/imap/table_imap_message.go
@@ -289,6 +289,12 @@ func tableIMAPParsedMessage(ctx context.Context, d *plugin.QueryData, h *plugin.
 	if utf8.ValidString(subject) {
 		te.Subject = subject
 	}
+	
+	// Even the messageID is not always valid UTF-8!
+	messageID := env.GetHeader("Message-Id")
+	if utf8.ValidString(messageID) {
+		te.MessageID = messageID
+	}	
 
 	from, err := env.AddressList("From")
 	if err == nil {


### PR DESCRIPTION
# Example query results
<details>
  <summary>Results</summary>
  
```
Add example SQL query results here (please include the input queries as well)
```
</details>
