### PR TITLE
message_id  will now return null if it is not valid UTF-8

### DIFF
--- a/imap/table_imap_message.go
+++ b/imap/table_imap_message.go
@@ -282,7 +282,6 @@ func tableIMAPParsedMessage(ctx context.Context, d *plugin.QueryData, h *plugin.
 		Mailbox:   mw.Mailbox,
 		Envelope:  env,
 		From:      env.GetHeader("From"),
-		MessageID: env.GetHeader("Message-Id"),
 		InReplyTo: env.GetHeaderValues("In-Reply-To"),
 	}
 


### PR DESCRIPTION
# Example query results
<details>
  <summary>Results</summary>
  
```
Add example SQL query results here (please include the input queries as well)
```
</details>
